### PR TITLE
Update PID_v1.cpp

### DIFF
--- a/PID_v1.cpp
+++ b/PID_v1.cpp
@@ -75,9 +75,8 @@ bool PID::Compute()
       else if(outputSum < outMin) outputSum= outMin;
 
       /*Add Proportional on Error, if P_ON_E is specified*/
-	   double output;
+	   double output = 0;
       if(pOnE) output = kp * error;
-      else output = 0;
 
       /*Compute Rest of PID Output*/
       output += outputSum - kd * dInput;


### PR DESCRIPTION
Don't need ```else output = 0``` because it becomes the default case during variable assignment ```double output = 0;```, if ```(!pOnE)```